### PR TITLE
Fix issue #4.

### DIFF
--- a/platform_msvc2012/lz4mt.vcxproj
+++ b/platform_msvc2012/lz4mt.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="..\lz4\xxhash.c" />
     <ClCompile Include="..\src\lz4mt.cpp" />
     <ClCompile Include="..\src\lz4mt_benchmark.cpp" />
+    <ClCompile Include="..\src\lz4mt_compat.cpp" />
     <ClCompile Include="..\src\lz4mt_io_cstdio.cpp" />
     <ClCompile Include="..\src\lz4mt_mempool.cpp" />
     <ClCompile Include="..\src\lz4mt_xxh32.cpp" />
@@ -35,6 +36,7 @@
     <ClInclude Include="..\lz4\xxhash.h" />
     <ClInclude Include="..\src\lz4mt.h" />
     <ClInclude Include="..\src\lz4mt_benchmark.h" />
+    <ClInclude Include="..\src\lz4mt_compat.h" />
     <ClInclude Include="..\src\lz4mt_io_cstdio.h" />
     <ClInclude Include="..\src\lz4mt_mempool.h" />
     <ClInclude Include="..\src\lz4mt_xxh32.h" />

--- a/platform_msvc2012/lz4mt.vcxproj.filters
+++ b/platform_msvc2012/lz4mt.vcxproj.filters
@@ -21,6 +21,7 @@
     <ClCompile Include="..\src\lz4mt_io_cstdio.cpp" />
     <ClCompile Include="..\src\lz4mt_xxh32.cpp" />
     <ClCompile Include="..\src\lz4mt_mempool.cpp" />
+    <ClCompile Include="..\src\lz4mt_compat.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\lz4\lz4.h">
@@ -37,5 +38,6 @@
     <ClInclude Include="..\src\lz4mt_io_cstdio.h" />
     <ClInclude Include="..\src\lz4mt_xxh32.h" />
     <ClInclude Include="..\src\lz4mt_mempool.h" />
+    <ClInclude Include="..\src\lz4mt_compat.h" />
   </ItemGroup>
 </Project>

--- a/src/lz4mt_benchmark.cpp
+++ b/src/lz4mt_benchmark.cpp
@@ -201,7 +201,7 @@ int Benchmark::measure(
 		std::vector<std::future<void>> futures(chunks.size());
 
 		const auto b = [=, &futures, &chunks]
-			(std::function<void(Chunk*)> fChunk)
+			(std::function<void(Chunk*)> fChunk) -> double
 		{
 			const auto t0 = getSyncTime();
 			auto t1 = t0;

--- a/src/lz4mt_compat.cpp
+++ b/src/lz4mt_compat.cpp
@@ -1,0 +1,62 @@
+#include <cassert>
+#include <future>
+
+#if defined(__GLIBC__)
+#include <sys/sysinfo.h> // get_nprocs()
+#endif
+
+#if defined(__APPLE__) || defined(__FreeBSD__)
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#endif
+#include "lz4mt_compat.h"
+
+
+#ifndef GCC_VERSION
+#  if defined(__GNUC__) && defined(__GNUC_MINOR__)
+#    define GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
+#  else
+#    define GCC_VERSION 0
+#  endif
+#endif
+
+#if (GCC_VERSION == 406)
+#  define LAUNCH_SINGLE_THREAD std::launch::sync
+#else
+#  define LAUNCH_SINGLE_THREAD std::launch::deferred
+#endif // defined(__GNUC__)
+
+const decltype(Lz4Mt::launch::deferred) Lz4Mt::launch::deferred = LAUNCH_SINGLE_THREAD;
+const decltype(Lz4Mt::launch::async)    Lz4Mt::launch::async    = std::launch::async;
+
+
+unsigned Lz4Mt::getHardwareConcurrency() {
+	{
+		const auto c = std::thread::hardware_concurrency();
+		if(c) {
+			return static_cast<unsigned>(c);
+		}
+	}
+
+	// following code is borrowed from boost-1.53.0/libs/thread/src/pthread/thread.cpp
+#if defined(__APPLE__) || defined(__FreeBSD__)
+	{ // ## NOT TESTED ##
+		int c = 0;
+		size_t size = sizeof(c);
+		if(0 == sysctlbyname("hw.ncpu", &count, &size, NULL, 0)) {
+			return static_cast<unsigned>(c);
+		}
+	}
+#endif
+
+#if defined(__GLIBC__)
+	{
+		auto c = get_nprocs();
+		if(c) {
+			return static_cast<unsigned>(c);
+		}
+	}
+#endif
+	assert(0);
+	return 8;
+}

--- a/src/lz4mt_compat.h
+++ b/src/lz4mt_compat.h
@@ -1,0 +1,20 @@
+#ifndef LZ4MT_COMPAT_H
+#define LZ4MT_COMPAT_H
+
+namespace Lz4Mt {
+
+unsigned getHardwareConcurrency();
+
+struct launch {
+#if defined(_MSC_VER)
+	typedef std::launch::launch Type;
+#else
+	typedef std::launch Type;
+#endif
+	static const Type deferred;
+	static const Type async;
+};
+
+}
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -196,7 +196,7 @@ int main(int argc, char* argv[]) {
 	}
 
 	if(!opt.overwrite && fileExist(opt.outFilename)) {
-		const int ch = [&] {
+		const int ch = [&]() -> int {
 			if("stdin" != opt.inpFilename) {
 				std::cerr << "Overwrite [y/N]? ";
 				return std::cin.get();
@@ -217,7 +217,7 @@ int main(int argc, char* argv[]) {
 	}
 
 	const auto t0 = Clock::now();
-	const auto e = [&] {
+	const auto e = [&]() -> Lz4MtResult {
 		if(opt.isCompress()) {
 			return lz4mtCompress(&ctx, &opt.sd);
 		} else if(opt.isDecompress()) {


### PR DESCRIPTION
- Add compatibility layer for older gcc (4.6 or older).
  - Add pseudo std::deffred. (Thanks for @billyevans)
  - Add fallback method for std::hardware_concurrency().
