### PR TITLE
Fix include paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CXX		= g++
 DUMPMACHINE	= $(shell gcc -dumpmachine)
 
 CFLAGS		= -Wall -W -Wextra -pedantic -O2 -std=c99
-CXXFLAGS	= -Wall -W -Wextra -pedantic -Weffc++ -Wno-missing-field-initializers -O2 -std=c++0x -Ilz4/
+CXXFLAGS	= -Wall -W -Wextra -pedantic -Weffc++ -Wno-missing-field-initializers -O2 -std=c++0x -Ilz4/ -Ilz4/programs
 
 LD		= $(CXX)
 LDFLAGS		=


### PR DESCRIPTION
Add `lz4/programs` to include paths, so that `"xxhash.h"` can be found.
